### PR TITLE
Fix for #28

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -416,7 +416,7 @@ function MQTTServer(adapter) {
             client._sendOnStart = null;
         }
         try {
-            if (clients[client.id]) {
+            if (clients[client.id] && (client.timestamp === clients[client.id].timestamp)) {
                 adapter.log.info('Client [' + client.id + '] ' + reason);
                 delete clients[client.id];
                 updateClients();
@@ -427,7 +427,7 @@ function MQTTServer(adapter) {
                 client.destroy();
             }
         } catch (e) {
-            adapter.warn('Cannot close client: ' + e);
+            adapter.log.warn('Cannot close client: ' + e);
         }
     }
 
@@ -444,22 +444,35 @@ function MQTTServer(adapter) {
             client.on('connect', function (options) {
                 // acknowledge the connect packet
                 client.id = options.clientId;
+                // store unique timestamp with each client
+                client.timestamp = new Date().getTime();
 
+                // get possible old client
+                let oldClient = clients[client.id];
+		    
                 if (config.user) {
                     if (config.user !== options.username ||
                         config.pass !== options.password.toString()) {
                         adapter.log.warn('Client [' + options.clientId + '] has invalid password(' + options.password + ') or username(' + options.username + ')');
                         client.connack({returnCode: 4});
-                        if (clients[client.id]) {
+                        if (oldClient) {
+                            // delete possible existing client
                             delete clients[client.id];
+                            updateClients();
+                            oldClient.destroy();
                         }
                         client.destroy();
-                        updateClients();
                         return;
                     }
                 }
 
-                adapter.log.info('Client [' + options.clientId + '] connected');
+                if (oldClient) {
+                    adapter.log.info('Client [' + client.id + '] reconnected');
+                    // need to destroy the old client
+                    oldClient.destroy();    
+                } else {
+                    adapter.log.info('Client [' + client.id + '] connected');
+                }
 
                 client.connack({returnCode: 0});
                 clients[client.id] = client;
@@ -503,11 +516,11 @@ function MQTTServer(adapter) {
             });
 
             client.on('pingreq', (/*packet*/) => {
-                if (clients[client.id]) {
+                if (clients[client.id] && (client.timestamp === clients[client.id].timestamp)) {
                     adapter.log.debug('Client [' + client.id + '] pingreq');
                     client.pingresp();
                 } else {
-                    adapter.log.debug('Received pingreq from disconnected client "' + client.id + '"');
+                    adapter.log.info('Received pingreq from disconnected client "' + client.id + '"');
                 }
             });
         });


### PR DESCRIPTION
Introduced a timestamp to each client to detect reconnects from same client in order
to gracefuly shutdown the old connection without interfering the new connection.