### PR TITLE
Set correct ON and OFF values for boolean states

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1209,7 +1209,11 @@ function MQTTServer(adapter) {
                     if (obj.data.common.type === 'number') {
                         adapter.setState(id, parseFloat(val), true);
                     } else if (obj.data.common.type === 'boolean') {
-                        adapter.setState(id, val === 'ON' || val === '1' || val === 'true' || val === 'on', true);
+                    	if (val === 'ON' || val === '1' || val === 'true' || val === 'on') {
+                            adapter.setState(id, true, true);                    		
+                    	} else if (val === 'OFF' || val === '0' || val === 'false' || val === 'off') {
+                            adapter.setState(id, false, true);
+                    	}
                     } else {
                         adapter.setState(id, val, true);
                     }
@@ -1220,7 +1224,11 @@ function MQTTServer(adapter) {
                     if (obj.data.common.type === 'number') {
                         adapter.setState(id, parseFloat(val), true);
                     } else if (obj.data.common.type === 'boolean') {
-                        adapter.setState(id, val === 'ON' || val === '1' || val === 'true' || val === 'on', true);
+                    	if (val === 'ON' || val === '1' || val === 'true' || val === 'on') {
+                            adapter.setState(id, true, true);                    		
+                    	} else if (val === 'OFF' || val === '0' || val === 'false' || val === 'off') {
+                            adapter.setState(id, false, true);
+                    	}
                     } else {
                         adapter.setState(id, val, true);
                     }


### PR DESCRIPTION
When a sonoff adapter instance is restarted, then the sonoff sends following command:
`22:47:01 MQT: cmnd/sonoff/POWER = `
This leads to invalid values in ioBroker, cause the state in ioBroker is then set to false, cause the cmnd does not match ON/on/1/true ...

This pull requests fixes the handling, so that a boolean state is changed to true, if ON/on/1/true is sent; but it also just sets the state to false if OFF/off/0/false was sent from the sonoff device.

Discussion also here:
https://forum.iobroker.net/viewtopic.php?f=36&t=8295&p=230795#p222799
