### PR TITLE
add scriptobjects for tasmota

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -779,9 +779,24 @@ function MQTTServer(adapter) {
             cb = retain;
             retain = undefined;
         }
-        adapter.log.debug('Send to "' + client.id + '": ' + topic + ' = ' + state);
-        client.publish({topic: topic, payload: state, qos: qos, retain: retain, messageId: messageId++}, cb);
-        messageId &= 0xFFFFFFFF;
+        var words = topic.split('/');
+        var sta = words[words.length - 1];
+        var id = adapter.namespace + '.' + client.id + '.' + sta;
+
+        adapter.getObject(id, (err, obj) => {
+            if (!obj) {
+                adapter.log.warn(`invalid  obj ${id}`);
+            } else {
+                const role = obj.common.role;
+                if (role == 'tasmotascript') {
+                    topic = words[0] + '/' + words[1] + '/Script';
+                    state = '>' + sta + '=' + state;
+                }
+            }
+            adapter.log.debug('Send to "' + client.id + '": ' + topic + ' = ' + state);
+            client.publish({ topic, payload: state, qos, retain, messageId: messageId++ }, cb);
+            messageId &= 0xFFFFFFFF;
+        });
     }
 
     function resendMessages2Client(client, messages, i) {


### PR DESCRIPTION
Here is another possibility in tasmota script to change variables without detours. The script variable is called the "tasmotascript" role, so the adapter knows that it is a script variable. The variable names are now freely selectable and do not get in the way of Tasmota's self-created variables.