### PR TITLE
(GreatSUN) Impl./Fixed potential .STATE.POWER only update synced with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ States:
 	### __WORK IN PROGRESS__
 -->
 ## Changelog
+### 2.5.2 (2023-01-21)
+* (GreatSUN) Impl./Fixed potential .STATE.POWER only update synced with .POWER switch
+
 ### 2.5.1 (2022-04-23)
 * (Apollon77) Fix crash case reported by Sentry
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1061,7 +1061,20 @@ function MQTTServer(adapter) {
                         val = data[attr];
                     }
                 }
+                let powerStateFound = false;
+                // due to some (for ex. NSPanel) versions do not automatically update .POWER from .STATE.POWER
+                // but this is generally a default for all devices (state cannot differ from switch) we now keep
+                // STATE changes to POWER in sync with POWER switches
+                if(obj.id.includes('.STATE.POWER')) {
+                    powerStateFound = true;
+                }
                 updateState(obj, val);
+                if(powerStateFound) {
+                    adapter.log.debug('Got .STATE.POWER update, auto syncing .POWER (src: ' + powerId + ')');
+                    let powerObj = Object.assign({}, obj);
+                    powerObj.id = powerObj.data._id = powerObj.id.replace('.STATE.POWER', '.POWER');
+                    updateState(powerObj, val);
+                }
             } else {
                 // not in list, auto insert
                 //if (client.id=='DVES_008ADB') {
@@ -1106,7 +1119,23 @@ function MQTTServer(adapter) {
 						}
 					};
 					obj.data.common.name = `${client.id} ${prefix ? `${prefix} ` : ''}${path.length ? `${path.join(' ')} ` : ''} ${replaceAttr}`;
+                    // due to some (for ex. NSPanel) versions do not automatically send .POWER switch data
+                    // but this is generally a default for all devices (state cannot exist without switch) we now add
+                    // POWER switches automatically if we get POWER STATE
+                    let powerStateFound = false;
+                    if(powerId.includes('.STATE.POWER')) {
+                        powerStateFound = true;
+                    }
 					updateState(obj, val);
+                    if(powerStateFound) {
+                        adapter.log.debug('Got .STATE.POWER value message -> auto add .POWER object from ' + obj.id);
+                        let powerId = obj.id.replace('.STATE.POWER', '.POWER');
+                        let powerName = obj.data.common.name.replace(' STATE POWER', ' POWER');
+                        let powerObj = Object.assign({}, obj);
+                        powerObj.id = powerObj.data._id = powerId;
+                        powerObj.data.common.name = powerName;
+                        updateState(powerObj, val);
+                    }
 				}
             }
         }


### PR DESCRIPTION
… .POWER switch

I recognized that the switches from NSPanel never get updated on status change, but the .STATUS.POWER changes the other way round (changing the switch in the object it reflects the change on the real switch) 