### PR TITLE
feat(adapter): add optional STAT_STATUS processing to generate Mac datapoint

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Objektbaum erstellen",
     "Divided by comma": "Mit Kommata getrennt, z.B 'mqtt/0/#,javascript/#'",
     "For stat/RESULT": "Für stat/RESULT",
+    "For stat/STATUS": "Für stat/STATUS",
     "For tele/SENSOR": "Für tele/SENSOR",
     "For tele/STATE": "Für tele/STATE",
     "IP": "IP",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Create object tree",
     "Divided by comma": "Divided by comma, e.g. 'mqtt/0/#,javascript/#'",
     "For stat/RESULT": "For stat/RESULT",
+    "For stat/STATUS": "For stat/STATUS",
     "For tele/SENSOR": "For tele/SENSOR",
     "For tele/STATE": "For tele/STATE",
     "For tele/SENSOR": "For tele/SENSOR",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -13,6 +13,7 @@
     "For stat/RESULT": "For stat/RESULT",
     "For tele/SENSOR": "For tele/SENSOR",
     "For tele/STATE": "For tele/STATE",
+    "For tele/SENSOR": "For tele/SENSOR",
     "IP": "IP",
     "Ignore warnings with pingreq": "Ignore warnings with pingreq",
     "Ignore 'not connected' warnings": "Ignore 'not connected' warnings",

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Crear árbol de objetos",
     "Divided by comma": "Dividido por coma, p. 'mqtt/0/#, javascript/#'",
     "For stat/RESULT": "Por stat/RESULT",
+    "For stat/STATUS": "Por stat/STATUS",
     "For tele/SENSOR": "Por tele/SENSOR",
     "For tele/STATE": "Por tele/STATE",
     "IP": "IP",

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Créer une arborescence d'objets",
     "Divided by comma": "Divisé par une virgule, par ex. 'mqtt/0/#, javascript/#'",
     "For stat/RESULT": "Pour stat/RESULT",
+    "For stat/STATUS": "Pour stat/STATUS",
     "For tele/SENSOR": "Pour tele/SENSOR",
     "For tele/STATE": "Pour tele/STATE",
     "IP": "IP",

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Crea l'albero degli oggetti",
     "Divided by comma": "Diviso in virgola, ad es. 'MQTT/0/#, JavaScript/#'",
     "For stat/RESULT": "Per stat/RESULT",
+    "For stat/STATUS": "Per stat/STATUS",
     "For tele/SENSOR": "Per tele/SENSOR",
     "For tele/STATE": "Per tele/STATE",
     "IP": "IP",

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Maak een objectboom",
     "Divided by comma": "Dividido por vírgula, e. 'mqtt/0/#, javascript/#'",
     "For stat/RESULT": "Voor stat/RESULT",
+    "For stat/STATUS": "Voor stat/STATUS",
     "For tele/SENSOR": "Voor tele/SENSOR",
     "For tele/STATE": "Voor tele/STATE",
     "IP": "IP",

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Utwórz drzewo obiektów",
     "Divided by comma": "Podzielone przecinkiem, np. \"mqtt / 0 / #, javascript / # '",
     "For stat/RESULT": "Dla stat/RESULT",
+    "For stat/STATUS": "Dla stat/STATUS",
     "For tele/SENSOR": "Dla tele/SENSOR",
     "For tele/STATE": "Dla tele/STATE",
     "IP": "IP",

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Criar árvore de objetos",
     "Divided by comma": "Dividido por vírgula, e. 'mqtt / 0 / #, javascript / #'",
     "For stat/RESULT": "Para stat/RESULT",
+    "For stat/STATUS": "Para stat/STATUS",
     "For tele/SENSOR": "Para tele/SENSOR",
     "For tele/STATE": "Para tele/STATE",
     "IP": "IP",

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Создать дерево объектов",
     "Divided by comma": "Использовать запятую, как разделитеть. Например 'mqtt/0/#,javascript/#'",
     "For stat/RESULT": "Для stat/RESULT",
+    "For stat/STATUS": "Для stat/STATUS",
     "For tele/SENSOR": "Для tele/SENSOR",
     "For tele/STATE": "Для tele/STATE",
     "IP": "IP",

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "Створення дерева об'єктів",
     "Divided by comma": "Розділяється комою, напр. 'mqtt/0/#,javascript/#'",
     "For stat/RESULT": "Для статистики/РЕЗУЛЬТАТУ",
+    "For stat/STATUS": "Для статистики/СТАТУС",
     "For tele/SENSOR": "Для теле/сенсора",
     "For tele/STATE": "Для теле/ДЕРЖ",
     "IP": "IP",

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -11,6 +11,7 @@
     "Create object tree": "创建对象树",
     "Divided by comma": "除以逗号，例如 'mqtt/0/#,javascript/#'",
     "For stat/RESULT": "对于统计/结果",
+    "For stat/STATUS": "对于统计/状况",
     "For tele/SENSOR": "对于电话/传感器",
     "For tele/STATE": "对于电话/状态",
     "IP": "IP",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -125,6 +125,15 @@
       "lg": 4,
       "xl": 4
     },
+    "STAT_STATUS": {
+      "type": "checkbox",
+      "label": "For stat/STATUS",
+      "xs": 12,
+      "sm": 12,
+      "md": 6,
+      "lg": 4,
+      "xl": 4
+    },
     "OBJ_TREE": {
       "type": "checkbox",
       "label": "Create object tree",

--- a/io-package.json
+++ b/io-package.json
@@ -180,6 +180,7 @@
     "TELE_SENSOR": true,
     "TELE_MARGINS": false,
     "TELE_STATE": true,
+    "STAT_STATUS": false,
     "STAT_RESULT": false,
     "OBJ_TREE": false,
     "storeClientsTime": 1440,

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -104,6 +104,7 @@ module.exports = {
     Leistung: { type: 'number', role: 'value.power.consumption', read: true, write: false, unit: 'W' },
     Light: { type: 'number', role: 'value', read: true, write: false, unit: 'lx' },
     Longitude: { type: 'number', role: 'value.gps.longitude', read: true, write: false, unit: '°' },
+    Mac: { type: 'string', role: 'state', read: true, write: false },
     Mode: { type: 'string', role: 'state', read: true, write: true },
     Module: { type: 'string', role: 'state', read: true, write: false },
     Noise: { type: 'number', role: 'value', read: true, write: false, unit: 'dB' },

--- a/lib/server.js
+++ b/lib/server.js
@@ -1367,7 +1367,8 @@ function MQTTServer(adapter) {
                             (adapter.config.STAT_RESULT && parts[2] === 'RESULT') ||
                             (adapter.config.TELE_STATE && parts[2] === 'STATE') ||
                             (adapter.config.TELE_MARGINS && parts[2] === 'MARGINS'))) ||
-                    (parts[0] === 'stat' && adapter.config.STAT_RESULT && parts[2] === 'RESULT')
+                    (parts[0] === 'stat' && adapter.config.STAT_RESULT && parts[2] === 'RESULT') ||
+                    (parts[0] === 'stat' && adapter.config.STAT_STATUS && parts[2].match(/^STATUS\d*$/))
                 ) {
                     let val = data[attr];
                     let attributes = { role: 'value', read: true, write: false };
@@ -1569,6 +1570,13 @@ function MQTTServer(adapter) {
                 checkData(client, packet.topic, 'MARGINS', JSON.parse(val));
             } catch (e) {
                 adapter.log.warn(`Client [${client.id}] cannot parse data"${stateId}": _${val}_ - ${e}`);
+            }
+        } else if (parts[0] === 'stat' && stateId.match(/^STATUS\d*$/) && adapter.config.STAT_STATUS) {
+            // stat/topic/STATUS5 = {"StatusNET": {...}}
+            try {
+                checkData(client, packet.topic, 'STATUS', JSON.parse(val));
+            } catch (e) {
+                adapter.log.warn(`Client [${client.id}] cannot parse STATUS data: ${e}`);
             }
         } else if (types[stateId]) {
             // /ESP_BOX/BM280/Pressure = 1010.09

--- a/lib/server.js
+++ b/lib/server.js
@@ -1368,7 +1368,7 @@ function MQTTServer(adapter) {
                             (adapter.config.TELE_STATE && parts[2] === 'STATE') ||
                             (adapter.config.TELE_MARGINS && parts[2] === 'MARGINS'))) ||
                     (parts[0] === 'stat' && adapter.config.STAT_RESULT && parts[2] === 'RESULT') ||
-                    (parts[0] === 'stat' && adapter.config.STAT_STATUS && parts[2].match(/^STATUS\d*$/))
+                    (parts[0] === 'stat' && adapter.config.STAT_STATUS && /^STATUS\d*$/.test(parts[2]))
                 ) {
                     let val = data[attr];
                     let attributes = { role: 'value', read: true, write: false };

--- a/test/integration.js
+++ b/test/integration.js
@@ -98,6 +98,8 @@ const rules = {
     'stat/sonoff_relay/RESULT':           {send: '{"PulseTime1":{"Set":100,"Remaining":95}}', expect: {'PulseTime1_Set': 100, 'PulseTime1_Remaining': 95}},
     'stat/multi_relay/RESULT':            {send: '{"PulseTime1":{"Set":50,"Remaining":0},"PulseTime2":{"Set":200,"Remaining":150}}', expect: {'PulseTime1_Set': 50, 'PulseTime1_Remaining': 0, 'PulseTime2_Set': 200, 'PulseTime2_Remaining': 150}},
     'stat/sonoff4ch/RESULT':              {send: '{"PulseTime3":{"Set":300,"Remaining":250}}', expect: {'PulseTime3_Set': 300, 'PulseTime3_Remaining': 250}},
+    // Generate MAC datapoint test
+    'stat/TestDevice/STATUS5':            {send: '{"StatusNET":{"Hostname":"Licht-4688","IPAddress":"192.168.0.50","Gateway":"192.168.0.1","Subnetmask":"255.255.255.0","DNSServer1":"1.1.1.1","DNSServer2":"8.8.8.8","Mac":"AB:CD:EF:01:23:45","Webserver":2,"HTTP_API":1,"WifiConfig":4,"WifiPower":17}}', expect: {'STATUS.StatusNET_Mac': 'AB:CD:EF:12:34:56', 'STATUS.StatusNET_IPAddress': '192.168.0.50', 'STATUS.StatusNET_Hostname': 'Licht-4688'}},
 };
 
 // Encrypt helper for password
@@ -135,7 +137,8 @@ tests.integration(path.join(__dirname, '..'), {
                         user: 'user',
                         password: encryptLegacy(secret, 'pass1'),
                         TELE_MARGINS: true,
-                        STAT_RESULT: true
+                        STAT_RESULT: true,
+                        STAT_STATUS: true
                     }
                 });
 


### PR DESCRIPTION
## 🆕 Processing of `stat/STATUS*` to generate the MAC datapoint

### Description
This pull request extends the Sonoff adapter with optional processing of `stat/STATUS*` MQTT topics. The primary purpose of this change is the **generation of the MAC address datapoint**, as **all Tasmota devices** publish the MAC address exclusively via **`stat/<topic>/STATUS5`**.

### Changes in detail

- **New configuration option**
  - Added `STAT_STATUS` checkbox to the admin UI
  - Enables processing of `stat/<topic>/STATUS*`

- **MQTT processing**
  - Extended topic detection to support `stat/STATUS\d*`
  - Parsing of STATUS payloads (`StatusNET`)

- **Datapoints**
  - Added new `Mac` datapoint
  - Automatically created when `StatusNET.Mac` is received

- **Tests**
  - Added integration test for `stat/.../STATUS5`
  - Extended test configuration with `STAT_STATUS`

### Motivation
The MAC address is a key identifier for Tasmota devices. Since it is not published via `tele` or `stat/RESULT` topics, but exclusively via `stat/STATUS5`, additional STATUS processing is required.
